### PR TITLE
use fewer scripts to build and run the code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,8 @@ Open in Visual Studio Code and run these tasks:
 ## Command Line Alternative
 
 ```shell
-cd projects/harness-browser3d-library
-
-npx openapi-typescript assets/geometry-api.yaml --output src/generated/geometry.ts
-
-ng build harness-browser3d-library --configuration production
-
-ng serve --open
+npm run watch:library
+npm start
 ```
 
 # Publishing

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "build library": "ng build harness-browser3d-library --configuration development"
+    "build:library": "npm run generate:api && ng build harness-browser3d-library --configuration development",
+    "watch:library": "npm run generate:api && ng build harness-browser3d-library --configuration development --watch",
+    "generate:api": "npx openapi-typescript projects/harness-browser3d-library/assets/geometry-api.yaml --output projects/harness-browser3d-library/src/generated/geometry.ts"
   },
   "dependencies": {
     "@angular/animations": "14.x",


### PR DESCRIPTION
I think, it would be easier to generate the api stubs together with the build step, since it runs very fast anyways. Also i believe it is unnecessary to cd into the api directory for generating the api stubs.